### PR TITLE
Feature/pretty stats reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ Requirement: `npm install nyc`
 | --spec                     | Test files pattern                                    | `glob`    | `**/test.html`                  |
 | --mock-api                 | Enables API Mock middleware                           | `boolean` | `false`                         |
 | --without-server           | Start testrunner without server                       | `boolean` | `false`                         |
-| --reporter                 | Test result reporter (`json`, `basic` or custom path) | `string`  | `basic`                         |
+| --reporter                 | Test result reporter (`json`, `basic`, `stats`        |           |                                 |
+|                            | or custom path)                                       | `string`  | `basic`                         |
 | --verbose, -v, -vv ...     | Verbose level                                         | `count`   | `0`                             |
 | --help -h                  | Display help                                          | `boolean` | `false`                         |
 |                            |                                                       |           |                                 |

--- a/bin/qunit-testrunner.js
+++ b/bin/qunit-testrunner.js
@@ -189,8 +189,7 @@ if (!withoutServer) {
     flow = flow.then(() => setupWebServer(params)
         .then(() => {
             const { host, testDir } = params;
-            const testDirectory = path.normalize(`/${testDir || '/'}`);
-            console.log(`Server is listening on http://${host}:${port}${testDirectory}`); // eslint-disable-line no-console
+            console.log(`Server is listening on http://${host}:${port}${path.normalize(`/${testDir}`)}`); // eslint-disable-line no-console
         })
     );
 }

--- a/bin/qunit-testrunner.js
+++ b/bin/qunit-testrunner.js
@@ -113,7 +113,8 @@ const setupWebServer = async (options) => {
         'coverage-output-dir': coverageOutput,
         'api-mock': apiMock,
         spec,
-        keepalive
+        keepalive,
+        testDir
     } = options;
     const middlewares = [bodyParser.json({ limit: '50mb' })];
 
@@ -152,7 +153,7 @@ const setupWebServer = async (options) => {
         middlewares
     });
 
-    return webServer.listen(port, host);
+    return webServer.listen(port, host, testDir);
 };
 
 const setupTestRunner = options => {

--- a/bin/qunit-testrunner.js
+++ b/bin/qunit-testrunner.js
@@ -113,8 +113,7 @@ const setupWebServer = async (options) => {
         'coverage-output-dir': coverageOutput,
         'api-mock': apiMock,
         spec,
-        keepalive,
-        testDir
+        keepalive
     } = options;
     const middlewares = [bodyParser.json({ limit: '50mb' })];
 
@@ -153,7 +152,7 @@ const setupWebServer = async (options) => {
         middlewares
     });
 
-    return webServer.listen(port, host, testDir);
+    return webServer.listen(port, host);
 };
 
 const setupTestRunner = options => {
@@ -187,7 +186,13 @@ if (!withoutServer) {
             params.port = freePort;
         });
     }
-    flow = flow.then(() => setupWebServer(params));
+    flow = flow.then(() => setupWebServer(params)
+        .then(() => {
+            const { host, testDir } = params;
+            const testDirectory = path.normalize(`/${testDir || '/'}`);
+            console.log(`Server is listening on http://${host}:${port}${testDirectory}`); // eslint-disable-line no-console
+        })
+    );
 }
 
 if (!keepalive) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-qunit-testrunner",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-qunit-testrunner",
-    "version": "0.1.4",
+    "version": "0.2.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-qunit-testrunner",
-    "version": "0.1.4",
+    "version": "0.2.0",
     "description": "TAO Frontend Unit & Integration Test Runner based on QUnit and Puppeteer",
     "files": [
         "bin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-qunit-testrunner",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "description": "TAO Frontend Unit & Integration Test Runner based on QUnit and Puppeteer",
     "files": [
         "bin",

--- a/src/reporter/stats.js
+++ b/src/reporter/stats.js
@@ -1,0 +1,83 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA ;
+ */
+
+/* eslint-disable no-console */
+
+const chalk = require('chalk');
+
+module.exports = {
+    onTestDone(result, verbose) {
+        if (result.stats.failed) {
+            printFailedTests(result, verbose);
+        } else {
+            printDetailedResult(result);
+        }
+    },
+    onDone() {
+        console.log();
+    }
+};
+
+/**
+ * Write failed test details to the console
+ * @param {object} result Test result
+ * @param {number} verbose Verbose level
+ */
+function printFailedTests(result, verbose) {
+    const { modules } = result;
+    console.group(chalk.redBright(result.path));
+    Object.keys(modules).forEach(moduleName => {
+        const moduleResult = modules[moduleName];
+        if (moduleResult.failed) {
+            console.group(moduleName);
+            moduleResult.tests.forEach(test => {
+                if (test.failed) {
+                    console.group(test.name);
+                    (test.log || []).forEach(log => {
+                        if (log.source) {
+                            console.log(log.message);
+                            if (verbose > 1) {
+                                console.log(log.source);
+                            }
+                        }
+                    });
+                    console.groupEnd();
+                }
+            });
+            console.groupEnd();
+        }
+    });
+    console.groupEnd();
+}
+
+/**
+ * Write test result statistics to the console
+ * @param {object} result Test result
+ */
+function printDetailedResult(result) {
+    const { stats } = result;
+    if (result.stats.failed) {
+        console.group(chalk.redBright(result.path));
+    } else {
+        console.group(chalk.greenBright(result.path));
+        Object.entries(stats).forEach(([ key, value ]) => {
+            console.log(`${key}:`, key === 'runtime' ? `${value}ms`: value);
+        });
+    }
+    console.groupEnd();
+}

--- a/src/webserver.js
+++ b/src/webserver.js
@@ -48,15 +48,17 @@ module.exports = function({ middlewares }) {
          * Start webserver
          * @param {number} port Port where listen
          * @param {string} host Host where host
+         * @param {string} testDir QUnit tests directory
          * @returns {Promise<void>} Promise about webserver listen
          */
-        listen(port, host) {
+        listen(port, host, testDir) {
             return new Promise((resolve, reject) => {
                 server.listen(port, host, err => {
+                    const testDirectory = testDir ? `${testDir}/` : '';
                     if (err) {
                         return reject(err);
                     }
-                    console.log(`Server is listening on http://${host}:${port}/`); // eslint-disable-line no-console
+                    console.log(`Server is listening on http://${host}:${port}/${testDirectory}`); // eslint-disable-line no-console
                     resolve();
                 });
             });

--- a/src/webserver.js
+++ b/src/webserver.js
@@ -18,7 +18,6 @@
 
 const connect = require('connect');
 const http = require('http');
-const path = require('path');
 
 /**
  * Web server factory
@@ -49,17 +48,14 @@ module.exports = function({ middlewares }) {
          * Start webserver
          * @param {number} port Port where listen
          * @param {string} host Host where host
-         * @param {string} testDir QUnit tests directory
          * @returns {Promise<void>} Promise about webserver listen
          */
-        listen(port, host, testDir) {
+        listen(port, host) {
             return new Promise((resolve, reject) => {
                 server.listen(port, host, err => {
-                    const testDirectory = path.normalize(`/${testDir || '/'}`);
                     if (err) {
                         return reject(err);
                     }
-                    console.log(`Server is listening on http://${host}:${port}${testDirectory}`); // eslint-disable-line no-console
                     resolve();
                 });
             });

--- a/src/webserver.js
+++ b/src/webserver.js
@@ -18,6 +18,7 @@
 
 const connect = require('connect');
 const http = require('http');
+const path = require('path');
 
 /**
  * Web server factory
@@ -54,11 +55,11 @@ module.exports = function({ middlewares }) {
         listen(port, host, testDir) {
             return new Promise((resolve, reject) => {
                 server.listen(port, host, err => {
-                    const testDirectory = testDir ? `${testDir}/` : '';
+                    const testDirectory = path.normalize(`/${testDir || '/'}`);
                     if (err) {
                         return reject(err);
                     }
-                    console.log(`Server is listening on http://${host}:${port}/${testDirectory}`); // eslint-disable-line no-console
+                    console.log(`Server is listening on http://${host}:${port}${testDirectory}`); // eslint-disable-line no-console
                     resolve();
                 });
             });


### PR DESCRIPTION
1. Added new reporter `stats`. It allows to output nice statistics like this:

`npm run test:stats ui/component/tour`

```
test/ui/component/tour/test.html
  passed: 53
  failed: 0
  total: 53
  runtime: 2674ms
```

2. Passed `testDir` param from `.qunit-testrunner.config.json` to `webserver.listen()` in order to have a correct listening webserver URL in CLI.

`Server is listening on http://127.0.0.1:8082/test/`
