### PR TITLE
Breaking: Added new Coverage option: Clear the Coverage output directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ Requirement: `npm install nyc`
 | --coverage, --cov          | Enable coverage measurement                           | `boolean` | `false`                         |
 | --coverage-instrument-spec | Coverage instrument pattern from `root`               | `glob`    | `src/**/*.js`                   |
 | --coverage-output-dir      | Coverage output directory in `root`                   | `string`  | `.nyc_output`                   |
-| --clear-coverage-dir,      | Clear the Coverage output directory before running    |           |                                 |
-| --clr-cov                  | test, when coverage option is enabled                 | `bool`    | `true`                          |
+| --clear-coverage-dir       | Clear the coverage output directory before running    |           |                                 |
+|                            | test, when coverage option is enabled                 | `bool`    | `true`                          |
 
 ### Config file
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Requirement: `npm install nyc`
 | --coverage, --cov          | Enable coverage measurement                           | `boolean` | `false`                         |
 | --coverage-instrument-spec | Coverage instrument pattern from `root`               | `glob`    | `src/**/*.js`                   |
 | --coverage-output-dir      | Coverage output directory in `root`                   | `string`  | `.nyc_output`                   |
+| --clear-coverage-dir,      | Clear the Coverage output directory before running    |           |                                 |
+| --clr-cov                  | test, when coverage option is enabled                 | `bool`    | `true`                          |
 
 ### Config file
 

--- a/bin/qunit-testrunner.js
+++ b/bin/qunit-testrunner.js
@@ -101,7 +101,6 @@ yargs
     })
     .option('clear-coverage-dir', {
         describe: 'Clear the coverage output directory before running test, when coverage option is enabled',
-        alias: 'clr-cov',
         default: true,
         boolean: true
     })

--- a/bin/qunit-testrunner.js
+++ b/bin/qunit-testrunner.js
@@ -99,6 +99,12 @@ yargs
         describe: 'Output of coverage info',
         default: '.nyc_output'
     })
+    .option('clear-coverage-dir', {
+        describe: 'Clear the Coverage output directory before running test, when coverage option is enabled',
+        alias: 'clr-cov',
+        default: true,
+        boolean: true
+    })
     .group(['coverage', 'coverage-instrument-spec', 'coverage-output-dir'], 'Coverage options:')
     .help('help')
     .alias('h', 'help');
@@ -111,6 +117,7 @@ const setupWebServer = async (options) => {
         coverage,
         'coverage-instrument-spec': instrumentSpec,
         'coverage-output-dir': coverageOutput,
+        'clear-coverage-dir': clearCoverageDir,
         'api-mock': apiMock,
         spec,
         keepalive
@@ -119,7 +126,9 @@ const setupWebServer = async (options) => {
 
     // add coverage middleware if measurement enabled
     if (coverage) {
-        await remove(coverageOutput);
+        if (clearCoverageDir) {
+            await remove(coverageOutput);
+        }
         middlewares.push(
             coverageMiddleware({
                 root,

--- a/bin/qunit-testrunner.js
+++ b/bin/qunit-testrunner.js
@@ -100,7 +100,7 @@ yargs
         default: '.nyc_output'
     })
     .option('clear-coverage-dir', {
-        describe: 'Clear the Coverage output directory before running test, when coverage option is enabled',
+        describe: 'Clear the coverage output directory before running test, when coverage option is enabled',
         alias: 'clr-cov',
         default: true,
         boolean: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-qunit-testrunner",
-    "version": "0.3.0",
+    "version": "1.0.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-qunit-testrunner",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-qunit-testrunner",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "TAO Frontend Unit & Integration Test Runner based on QUnit and Puppeteer",
     "files": [
         "bin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-qunit-testrunner",
-    "version": "0.3.0",
+    "version": "1.0.0",
     "description": "TAO Frontend Unit & Integration Test Runner based on QUnit and Puppeteer",
     "files": [
         "bin",


### PR DESCRIPTION
Added new option: Clear the Coverage output directory;

Initially was implemented in this closed PR: https://github.com/oat-sa/tao-qunit-testrunner-fe/pull/10