### PR TITLE
Fix/undefined port on console

### DIFF
--- a/.qunit-testrunner.config.json
+++ b/.qunit-testrunner.config.json
@@ -1,6 +1,5 @@
 {
     "verbose": 1,
     "testDir": "exampleTest",
-    "coverage-instrument-spec": "exampleSrc/**/*.js",
-    "port": 8082
+    "coverage-instrument-spec": "exampleSrc/**/*.js"
 }

--- a/bin/qunit-testrunner.js
+++ b/bin/qunit-testrunner.js
@@ -180,7 +180,6 @@ const setupTestRunner = options => {
 
 const params = yargs.argv;
 const { withoutServer, keepalive } = params;
-let { port } = params;
 
 if (params._[0]) {
     params.spec = path.join('**', params._[0], params.spec);
@@ -189,14 +188,14 @@ if (params._[0]) {
 let flow = Promise.resolve();
 
 if (!withoutServer) {
-    if (!port) {
+    if (!params.port) {
         flow = flow.then(getPort).then(freePort => {
             params.port = freePort;
         });
     }
     flow = flow.then(() => setupWebServer(params)
         .then(() => {
-            const { host, testDir } = params;
+            const { host, port, testDir } = params;
             console.log(`Server is listening on http://${host}:${port}${path.normalize(`/${testDir}`)}`); // eslint-disable-line no-console
         })
     );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-qunit-testrunner",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-qunit-testrunner",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "TAO Frontend Unit & Integration Test Runner based on QUnit and Puppeteer",
     "files": [
         "bin",


### PR DESCRIPTION
When port was not defined in config and test runner get a free port, then after the start `undefined` was written to the console as a port. Fix will console log the gotten free port.

Test: `npm run test`