### PR TITLE
fix: Add CodeRabbit configuration file

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,2 @@
+remote_config:
+  url: 'https://raw.githubusercontent.com/oat-sa/tao-code-quality/main/coderabbit/js/authoring/v1/.coderabbit.yaml'


### PR DESCRIPTION
## Summary
- add `.coderabbit.yaml` for `tao-qunit-testrunner-fe`
- rules coverage: 44 matches

## Rules coverage
| Rule | Matches |
| --- | ---: |
| `**/*.js` | 18 |
| `**/*.{js,svelte}` | 18 |
| `**/*.{html,tpl,jst}` | 7 |
| `**/package.json` | 1 |
| `**/*.svelte` | 0 |
| `**/*.{scss,css}` | 0 |
| `**/*.{spec,test}.js` | 0 |



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration infrastructure to support remote configuration fetching.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->